### PR TITLE
Use grad init by default and introduce early mass matrix switch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ ndarray = "0.15.4"
 [dev-dependencies]
 proptest = "1.0.0"
 pretty_assertions = "1.2.1"
-criterion = "0.3.5"
+criterion = "0.4.0"
 nix = "0.25.0"
 approx = "0.5.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nuts-rs"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Adrian Seyboldt <adrian.seyboldt@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/src/adapt_strategy.rs
+++ b/src/adapt_strategy.rs
@@ -189,13 +189,13 @@ impl<F: CpuLogpFunc> AdaptStrategy for ExpWindowDiagAdapt<F> {
                     1f64
                 } else {
                     let out = val * val;
-                    if out == 0f64 {
+                    let out = out.clamp(LOWER_LIMIT * LOWER_LIMIT, UPPER_LIMIT * UPPER_LIMIT);
+                    if (out == 0f64) | (!out.is_finite()) {
                         1f64
                     } else {
                         out
                     }
                 };
-                assert!(diag.is_finite());
                 diag
             }));
         self.exp_variance_grad.set_mean(iter::repeat(0f64));
@@ -207,8 +207,11 @@ impl<F: CpuLogpFunc> AdaptStrategy for ExpWindowDiagAdapt<F> {
             )
             .map(|(draw, grad)| {
                 let val = (draw / grad).sqrt().clamp(LOWER_LIMIT, UPPER_LIMIT);
-                assert!(val.is_finite());
-                val
+                if val.is_finite() {
+                    val
+                } else {
+                    1f64
+                }
             }),
         );
     }

--- a/src/cpu_sampler.rs
+++ b/src/cpu_sampler.rs
@@ -131,7 +131,9 @@ pub fn sample_parallel<F: CpuLogpFuncMaker + 'static, I: InitPointFunc>(
         .collect();
 
     let points: Result<Vec<(Box<[f64]>, Box<[f64]>)>, _> = points.drain(..).collect();
-    let points = points.map_err(|e| NutsError::LogpFailure(Box::new(e)))?;
+    let points = points.map_err(|e| ParallelSamplingError::InitError {
+        source: NutsError::LogpFailure(Box::new(e)),
+    })?;
 
     let (sender, receiver) = crossbeam::channel::bounded(128);
 
@@ -340,9 +342,8 @@ mod tests {
     use std::error::Error;
 
     use crate::{
-        sample_parallel, sample_sequentially,
-        test_logps::NormalLogp, CpuLogpFunc, CpuLogpFuncMaker, JitterInitFunc, SampleStats,
-        SamplerArgs,
+        sample_parallel, sample_sequentially, test_logps::NormalLogp, CpuLogpFunc,
+        CpuLogpFuncMaker, JitterInitFunc, SampleStats, SamplerArgs,
     };
 
     use itertools::Itertools;

--- a/src/cpu_sampler.rs
+++ b/src/cpu_sampler.rs
@@ -5,10 +5,10 @@ use thiserror::Error;
 
 use crate::{
     adapt_strategy::{
-        CombinedStrategy, DualAverageSettings, DualAverageStrategy, ExpWindowDiagAdapt,
+        DualAverageSettings, GradDiagStrategy, GradDiagOptions
     },
     cpu_potential::EuclideanPotential,
-    mass_matrix::{DiagAdaptExpSettings, DiagMassMatrix},
+    mass_matrix::DiagMassMatrix,
     nuts::{Chain, NutsChain, NutsError, NutsOptions, SampleStats},
     CpuLogpFunc,
 };
@@ -29,7 +29,7 @@ pub struct SamplerArgs {
     /// Settings for step size adaptation.
     pub step_size_adapt: DualAverageSettings,
     /// Settings for mass matrix adaptation.
-    pub mass_matrix_adapt: DiagAdaptExpSettings,
+    pub mass_matrix_adapt: GradDiagOptions,
 }
 
 impl Default for SamplerArgs {
@@ -40,7 +40,7 @@ impl Default for SamplerArgs {
             max_energy_error: 1000f64,
             store_gradient: false,
             step_size_adapt: DualAverageSettings::default(),
-            mass_matrix_adapt: DiagAdaptExpSettings::default(),
+            mass_matrix_adapt: GradDiagOptions::default(),
         }
     }
 }
@@ -175,11 +175,11 @@ pub fn new_sampler<F: CpuLogpFunc>(
 ) -> impl Chain {
     use crate::nuts::AdaptStrategy;
     let num_tune = settings.num_tune;
-    let step_size_adapt = DualAverageStrategy::new(settings.step_size_adapt, num_tune, logp.dim());
-    let mass_matrix_adapt =
-        ExpWindowDiagAdapt::new(settings.mass_matrix_adapt, num_tune, logp.dim());
+    //let step_size_adapt = DualAverageStrategy::new(settings.step_size_adapt, num_tune, logp.dim());
+    //let mass_matrix_adapt =
+    //    ExpWindowDiagAdapt::new(settings.mass_matrix_adapt, num_tune, logp.dim());
 
-    let strategy = CombinedStrategy::new(step_size_adapt, mass_matrix_adapt);
+    let strategy = GradDiagStrategy::new(settings.mass_matrix_adapt, num_tune, logp.dim());
 
     let mass_matrix = DiagMassMatrix::new(logp.dim());
     let max_energy_error = settings.max_energy_error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,6 @@
 //! // and modify as we like
 //! sampler_args.num_tune = 1000;
 //! sampler_args.maxdepth = 3;  // small value just for testing...
-//! sampler_args.mass_matrix_adapt.store_mass_matrix = true;
 //!
 //! // We instanciate our posterior density function
 //! let logp_func = PosteriorDensity {};
@@ -111,5 +110,4 @@ pub use cpu_sampler::{
     new_sampler, sample_parallel, sample_sequentially, CpuLogpFuncMaker, InitPointFunc,
     JitterInitFunc, ParallelChainResult, ParallelSamplingError, SamplerArgs,
 };
-pub use mass_matrix::DiagAdaptExpSettings;
 pub use nuts::{Chain, DivergenceInfo, LogpError, NutsError, SampleStatValue, SampleStats};

--- a/src/mass_matrix.rs
+++ b/src/mass_matrix.rs
@@ -164,6 +164,7 @@ pub struct DiagAdaptExpSettings {
     pub store_mass_matrix: bool,
     /// Switch to a new variance estimator every `window_switch_freq` draws.
     pub window_switch_freq: u64,
+    pub early_window_switch_freq: u64,
     pub grad_init: bool,
 }
 
@@ -174,8 +175,9 @@ impl Default for DiagAdaptExpSettings {
             final_window: 50,
             store_mass_matrix: false,
             window_switch_freq: 50,
+            early_window_switch_freq: 10,
             early_variance_decay: 0.1,
-            grad_init: false,
+            grad_init: true,
         }
     }
 }

--- a/src/mass_matrix.rs
+++ b/src/mass_matrix.rs
@@ -143,10 +143,14 @@ impl DrawGradCollector {
 impl Collector for DrawGradCollector {
     type State = State;
 
-    fn register_draw(&mut self, state: &Self::State, _info: &crate::nuts::SampleInfo) {
+    fn register_draw(&mut self, state: &Self::State, info: &crate::nuts::SampleInfo) {
         self.draw.copy_from_slice(&state.q);
         self.grad.copy_from_slice(&state.grad);
         let idx = state.index_in_trajectory();
-        self.is_good = _info.divergence_info.is_none() & (idx != 0);
+        if info.divergence_info.is_some() {
+            self.is_good = idx.abs() > 4;
+        } else {
+            self.is_good = idx != 0;
+        }
     }
 }

--- a/src/stepsize.rs
+++ b/src/stepsize.rs
@@ -8,7 +8,6 @@ pub struct DualAverageOptions {
     pub k: f64,
     pub t0: f64,
     pub gamma: f64,
-    pub initial_step: f64,
 }
 
 impl Default for DualAverageOptions {
@@ -17,7 +16,6 @@ impl Default for DualAverageOptions {
             k: 0.75,
             t0: 10.,
             gamma: 0.05,
-            initial_step: 0.1,
         }
     }
 }
@@ -33,14 +31,12 @@ pub struct DualAverage {
 }
 
 impl DualAverage {
-    pub fn new(settings: DualAverageOptions) -> DualAverage {
-        let initial_step = settings.initial_step;
+    pub fn new(settings: DualAverageOptions, initial_step: f64) -> DualAverage {
         DualAverage {
             log_step: initial_step.ln(),
             log_step_adapted: initial_step.ln(),
             hbar: 0.,
-            //mu: (10. * initial_step).ln(),
-            mu: (2. * initial_step).ln(),
+            mu: (10. * initial_step).ln(),
             count: 1,
             settings,
         }
@@ -64,11 +60,11 @@ impl DualAverage {
     }
 
     #[allow(dead_code)]
-    pub fn reset(&mut self, initial_step: f64) {
+    pub fn reset(&mut self, initial_step: f64, bias_factor: f64) {
         self.log_step = initial_step.ln();
         self.log_step_adapted = initial_step.ln();
         self.hbar = 0f64;
-        self.mu = (10f64 * initial_step).ln();
+        self.mu = (bias_factor * initial_step).ln();
         self.count = 1;
     }
 }


### PR DESCRIPTION
This enables `grad_init` by default. grad_init initializes the very first mass matrix estimate using the gradient at the initial position, which improves early tuning behavior.