### PR TITLE
WIP Rewrite sample stats to use apache arrow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ thiserror = "1.0.31"
 rayon = "1.5.3"
 ndarray = "0.15.4"
 arrow2 = { version = "0.17.0", optional = true }
+rand_chacha = "0.3.1"
+anyhow = "1.0.70"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ itertools = "0.11.0"
 crossbeam = "0.8.2"
 thiserror = "1.0.40"
 rayon = "1.7.0"
-ndarray = "0.15.6"
 arrow2 = { version = "0.17.2", optional = true }
 rand_chacha = "0.3.1"
 anyhow = "1.0.71"
@@ -39,6 +38,7 @@ pretty_assertions = "1.3.0"
 criterion = "0.5.1"
 nix = "0.26.2"
 approx = "0.5.1"
+ndarray = "0.15.6"
 
 [[bench]]
 name = "sample"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,21 +23,21 @@ codegen-units = 1
 [dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
-multiversion = "0.7.0"
-itertools = "0.10.3"
-crossbeam = "0.8.1"
-thiserror = "1.0.31"
-rayon = "1.5.3"
-ndarray = "0.15.4"
+multiversion = "0.7.1"
+itertools = "0.10.5"
+crossbeam = "0.8.2"
+thiserror = "1.0.40"
+rayon = "1.7.0"
+ndarray = "0.15.6"
 arrow2 = { version = "0.17.0", optional = true }
 rand_chacha = "0.3.1"
 anyhow = "1.0.70"
 
 [dev-dependencies]
-proptest = "1.0.0"
-pretty_assertions = "1.2.1"
+proptest = "1.1.0"
+pretty_assertions = "1.3.0"
 criterion = "0.4.0"
-nix = "0.26.1"
+nix = "0.26.2"
 approx = "0.5.1"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ codegen-units = 1
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
 multiversion = "0.7.2"
-itertools = "0.10.5"
+itertools = "0.11.0"
 crossbeam = "0.8.2"
 thiserror = "1.0.40"
 rayon = "1.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ crossbeam = "0.8.1"
 thiserror = "1.0.31"
 rayon = "1.5.3"
 ndarray = "0.15.4"
+arrow2 = { version = "0.17.0", optional = true }
 
 [dev-dependencies]
 proptest = "1.0.0"
@@ -43,5 +44,7 @@ harness = false
 
 [features]
 nightly = ["simd_support"]
+default = ["arrow"]
 
 simd_support = []
+arrow = ["dep:arrow2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,20 +23,20 @@ codegen-units = 1
 [dependencies]
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
-multiversion = "0.7.1"
+multiversion = "0.7.2"
 itertools = "0.10.5"
 crossbeam = "0.8.2"
 thiserror = "1.0.40"
 rayon = "1.7.0"
 ndarray = "0.15.6"
-arrow2 = { version = "0.17.0", optional = true }
+arrow2 = { version = "0.17.2", optional = true }
 rand_chacha = "0.3.1"
-anyhow = "1.0.70"
+anyhow = "1.0.71"
 
 [dev-dependencies]
-proptest = "1.1.0"
+proptest = "1.2.0"
 pretty_assertions = "1.3.0"
-criterion = "0.4.0"
+criterion = "0.5.1"
 nix = "0.26.2"
 approx = "0.5.1"
 

--- a/src/adapt_strategy.rs
+++ b/src/adapt_strategy.rs
@@ -686,6 +686,7 @@ mod test {
         let options = NutsOptions {
             maxdepth: 10u64,
             store_gradient: true,
+            store_unconstrained: true,
         };
 
         let rng = {

--- a/src/cpu_potential.rs
+++ b/src/cpu_potential.rs
@@ -23,7 +23,7 @@ use crate::nuts::{ArrowBuilder, ArrowRow};
 /// If a non-recoverable error occurs during sampling, the sampler will
 /// stop and return an error.
 pub trait CpuLogpFunc {
-    type Err: Debug + Send + LogpError + 'static;
+    type Err: Debug + Send + Sync + LogpError + 'static;
 
     fn logp(&mut self, position: &[f64], grad: &mut [f64]) -> Result<f64, Self::Err>;
     fn dim(&self) -> usize;

--- a/src/cpu_potential.rs
+++ b/src/cpu_potential.rs
@@ -63,12 +63,12 @@ impl ArrowBuilder<PotentialStats> for PotentialStatsBuilder {
         self.step_size.push(Some(value.step_size));
     }
 
-    fn finalize(mut self) -> StructArray {
+    fn finalize(mut self) -> Option<StructArray> {
         let fields = vec![Field::new("step_size", DataType::Float64, false)];
 
         let arrays = vec![self.step_size.as_box()];
 
-        StructArray::new(DataType::Struct(fields), arrays, None)
+        Some(StructArray::new(DataType::Struct(fields), arrays, None))
     }
 }
 

--- a/src/cpu_sampler.rs
+++ b/src/cpu_sampler.rs
@@ -23,9 +23,13 @@ pub struct SamplerArgs {
     pub maxdepth: u64,
     /// Store the gradient in the SampleStats
     pub store_gradient: bool,
+    /// Store each unconstrained parameter vector in the sampler stats
+    pub store_unconstrained: bool,
     /// If the energy error is larger than this threshold we treat the leapfrog
     /// step as a divergence.
     pub max_energy_error: f64,
+    /// Store detailed information about each divergence in the sampler stats
+    pub store_divergences: bool,
     /// Settings for step size adaptation.
     pub step_size_adapt: DualAverageSettings,
     /// Settings for mass matrix adaptation.
@@ -40,6 +44,8 @@ impl Default for SamplerArgs {
             maxdepth: 10,
             max_energy_error: 1000f64,
             store_gradient: false,
+            store_unconstrained: false,
+            store_divergences: true,
             step_size_adapt: DualAverageSettings::default(),
             mass_matrix_adapt: GradDiagOptions::default(),
         }

--- a/src/cpu_state.rs
+++ b/src/cpu_state.rs
@@ -119,7 +119,7 @@ impl Drop for AlignedArray {
 impl Clone for AlignedArray {
     fn clone(&self) -> Self {
         let mut new = AlignedArray::new(self.size);
-        new.copy_from_slice(&self);
+        new.copy_from_slice(self);
         new
     }
 }
@@ -214,9 +214,9 @@ impl crate::nuts::State for State {
 
     fn is_turning(&self, other: &Self) -> bool {
         let (start, end) = if self.idx_in_trajectory < other.idx_in_trajectory {
-            (&*self, other)
+            (self, other)
         } else {
-            (other, &*self)
+            (other, self)
         };
 
         let a = start.idx_in_trajectory;

--- a/src/cpu_state.rs
+++ b/src/cpu_state.rs
@@ -188,10 +188,6 @@ impl State {
             None => Err(StateInUse {}),
         }
     }
-
-    pub(crate) fn clone_inner(&self) -> InnerState {
-        self.inner.inner.clone()
-    }
 }
 
 impl Drop for State {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,4 +107,6 @@ pub use cpu_sampler::{
     new_sampler, sample_parallel, sample_sequentially, CpuLogpFuncMaker, InitPointFunc,
     JitterInitFunc, ParallelChainResult, ParallelSamplingError, SamplerArgs,
 };
+#[cfg(feature = "arrow")]
+pub use nuts::ArrowBuilder;
 pub use nuts::{Chain, DivergenceInfo, LogpError, NutsError, SampleStats};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,17 +66,14 @@
 //! // Set to some initial position and start drawing samples.
 //! sampler.set_position(&vec![0f64; 10]).expect("Unrecoverable error during init");
 //! let mut trace = vec![];  // Collection of all draws
-//! let mut stats = vec![];  // Collection of statistics like the acceptance rate for each draw
 //! for _ in 0..2000 {
 //!     let (draw, info) = sampler.draw().expect("Unrecoverable error during sampling");
 //!     trace.push(draw);
-//!     let _info_vec = info.to_vec();  // We can collect the stats in a Vec
 //!     // Or get more detailed information about divergences
 //!     if let Some(div_info) = info.divergence_info() {
-//!         println!("Divergence at position {:?}", div_info.start_location());
+//!         println!("Divergence at position {:?}", div_info.start_location);
 //!     }
 //!     dbg!(&info);
-//!     stats.push(info);
 //! }
 //! ```
 //!
@@ -110,4 +107,4 @@ pub use cpu_sampler::{
     new_sampler, sample_parallel, sample_sequentially, CpuLogpFuncMaker, InitPointFunc,
     JitterInitFunc, ParallelChainResult, ParallelSamplingError, SamplerArgs,
 };
-pub use nuts::{Chain, DivergenceInfo, LogpError, NutsError, SampleStatValue, SampleStats};
+pub use nuts::{Chain, DivergenceInfo, LogpError, NutsError, SampleStats};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 //! ```
 //! use nuts_rs::{CpuLogpFunc, LogpError, new_sampler, SamplerArgs, Chain, SampleStats};
 //! use thiserror::Error;
+//! use rand::thread_rng;
 //!
 //! // Define a function that computes the unnormalized posterior density
 //! // and its gradient.
@@ -60,8 +61,8 @@
 //! let logp_func = PosteriorDensity {};
 //!
 //! let chain = 0;
-//! let seed = 42;
-//! let mut sampler = new_sampler(logp_func, sampler_args, chain, seed);
+//! let mut rng = thread_rng();
+//! let mut sampler = new_sampler(logp_func, sampler_args, chain, &mut rng);
 //!
 //! // Set to some initial position and start drawing samples.
 //! sampler.set_position(&vec![0f64; 10]).expect("Unrecoverable error during init");
@@ -108,5 +109,5 @@ pub use cpu_sampler::{
     JitterInitFunc, ParallelChainResult, ParallelSamplingError, SamplerArgs,
 };
 #[cfg(feature = "arrow")]
-pub use nuts::ArrowBuilder;
+pub use nuts::{ArrowBuilder, ArrowRow};
 pub use nuts::{Chain, DivergenceInfo, LogpError, NutsError, SampleStats};

--- a/src/mass_matrix.rs
+++ b/src/mass_matrix.rs
@@ -84,7 +84,6 @@ pub(crate) struct RunningVariance {
     count: u64,
 }
 
-
 impl RunningVariance {
     pub(crate) fn new(dim: usize) -> Self {
         Self {
@@ -97,17 +96,17 @@ impl RunningVariance {
     pub(crate) fn add_sample(&mut self, value: impl Iterator<Item = f64>) {
         self.count += 1;
         if self.count == 1 {
-            izip!(self.mean.iter_mut(), value)
-                .for_each(|(mean, val)| {
-                    *mean = val;
-                });
+            izip!(self.mean.iter_mut(), value).for_each(|(mean, val)| {
+                *mean = val;
+            });
         } else {
-            izip!(self.mean.iter_mut(), self.variance.iter_mut(), value)
-                .for_each(|(mean, var, x)| {
+            izip!(self.mean.iter_mut(), self.variance.iter_mut(), value).for_each(
+                |(mean, var, x)| {
                     let diff = x - *mean;
                     *mean += diff / (self.count as f64);
                     *var += diff * diff;
-                });
+                },
+            );
         }
     }
 
@@ -120,7 +119,6 @@ impl RunningVariance {
         self.count
     }
 }
-
 
 pub(crate) struct DrawGradCollector {
     pub(crate) draw: Box<[f64]>,

--- a/src/math.rs
+++ b/src/math.rs
@@ -207,8 +207,8 @@ pub fn vector_dot(a: &[f64], b: &[f64]) -> f64 {
     assert!(a.len() == b.len());
 
     let mut result = 0f64;
-    for (val1, val2) in a.iter().zip(b) {
-        result += *val1 * *val2;
+    for (&val1, &val2) in a.iter().zip(b) {
+        result += val1 * val2;
     }
     result
 }

--- a/src/math.rs
+++ b/src/math.rs
@@ -290,7 +290,6 @@ pub fn axpy_out(x: &[f64], y: &[f64], a: f64, out: &mut [f64]) {
 mod tests {
     use super::*;
     use approx::assert_ulps_eq;
-    use ndarray::prelude::*;
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
 

--- a/src/nuts.rs
+++ b/src/nuts.rs
@@ -634,7 +634,7 @@ impl<H: Hamiltonian, A: AdaptStrategy> ArrowBuilder<NutsSampleStats<H::Stats, A:
         }
 
         if let Some(mut unconstrained) = self.unconstrained.take() {
-            fields.push(Field::new("unconstrained", unconstrained.data_type().clone(), true));
+            fields.push(Field::new("unconstrained_draw", unconstrained.data_type().clone(), true));
             arrays.push(unconstrained.as_box());
         }
 

--- a/src/nuts.rs
+++ b/src/nuts.rs
@@ -15,7 +15,7 @@ use crate::SamplerArgs;
 #[derive(Error, Debug)]
 pub enum NutsError {
     #[error("Logp function returned error: {0}")]
-    LogpFailure(Box<dyn std::error::Error + Send>),
+    LogpFailure(Box<dyn std::error::Error + Send + Sync>),
 
     #[error("Could not serialize sample stats")]
     SerializeFailure(),

--- a/src/nuts.rs
+++ b/src/nuts.rs
@@ -527,14 +527,18 @@ impl<H: Hamiltonian, A: AdaptStrategy> StatsBuilder<H, A> {
 
         let gradient = if settings.store_gradient {
             let items = MutablePrimitiveArray::new();
-            Some(MutableFixedSizeListArray::new_with_field(items, "item", false, dim))
+            Some(MutableFixedSizeListArray::new_with_field(
+                items, "item", false, dim,
+            ))
         } else {
             None
         };
 
         let unconstrained = if settings.store_gradient {
             let items = MutablePrimitiveArray::new();
-            Some(MutableFixedSizeListArray::new_with_field(items, "item", false, dim))
+            Some(MutableFixedSizeListArray::new_with_field(
+                items, "item", false, dim,
+            ))
         } else {
             None
         };
@@ -572,9 +576,9 @@ impl<H: Hamiltonian, A: AdaptStrategy> ArrowBuilder<NutsSampleStats<H::Stats, A:
             store
                 .try_push(
                     value
-                    .gradient()
-                    .as_ref()
-                    .map(|vals| vals.iter().map(|&x| Some(x)))
+                        .gradient()
+                        .as_ref()
+                        .map(|vals| vals.iter().map(|&x| Some(x))),
                 )
                 .unwrap();
         }
@@ -583,9 +587,9 @@ impl<H: Hamiltonian, A: AdaptStrategy> ArrowBuilder<NutsSampleStats<H::Stats, A:
             store
                 .try_push(
                     value
-                    .unconstrained()
-                    .as_ref()
-                    .map(|vals| vals.iter().map(|&x| Some(x)))
+                        .unconstrained()
+                        .as_ref()
+                        .map(|vals| vals.iter().map(|&x| Some(x))),
                 )
                 .unwrap();
         }
@@ -634,7 +638,11 @@ impl<H: Hamiltonian, A: AdaptStrategy> ArrowBuilder<NutsSampleStats<H::Stats, A:
         }
 
         if let Some(mut unconstrained) = self.unconstrained.take() {
-            fields.push(Field::new("unconstrained_draw", unconstrained.data_type().clone(), true));
+            fields.push(Field::new(
+                "unconstrained_draw",
+                unconstrained.data_type().clone(),
+                true,
+            ));
             arrays.push(unconstrained.as_box());
         }
 

--- a/src/stepsize.rs
+++ b/src/stepsize.rs
@@ -1,6 +1,9 @@
 use std::marker::PhantomData;
 
-use crate::nuts::{Collector, NutsOptions, State};
+use crate::{
+    nuts::{Collector, NutsOptions, State},
+    DivergenceInfo,
+};
 
 /// Settings for step size adaptation
 #[derive(Debug, Clone, Copy)]
@@ -121,7 +124,7 @@ impl<S: State> Collector for AcceptanceRateCollector<S> {
         &mut self,
         _start: &Self::State,
         end: &Self::State,
-        divergence_info: Option<&dyn crate::nuts::DivergenceInfo>,
+        divergence_info: Option<&DivergenceInfo>,
     ) {
         match divergence_info {
             Some(_) => self.mean.add(0.),


### PR DESCRIPTION
This adds a new optional dependency to arrow and if it is enabled, sample stats can be collected in arrow arrays. This makes it easier for other libraries to collect the sampler stats into a trace.

The old custom system that uses an enum to describe the different datatypes is removed, so this is a breaking change.

TODO: Add back in divergance meta information.