### PR TITLE
Use 1. as initial mass matrix if grad is zero

### DIFF
--- a/src/adapt_strategy.rs
+++ b/src/adapt_strategy.rs
@@ -352,7 +352,8 @@ impl<F: CpuLogpFunc> AdaptStrategy for ExpWindowDiagAdapt<F> {
             state
                 .grad
                 .iter()
-                .map(|&grad| Some((grad).abs().recip().clamp(LOWER_LIMIT, UPPER_LIMIT))),
+                .map(|&grad| grad.abs().recip().clamp(LOWER_LIMIT, UPPER_LIMIT))
+                .map(|var| if var.is_finite() { Some(var) } else { Some(1.) })
         );
     }
 


### PR DESCRIPTION
We initialize the mass matrix using 1/grad at the initial point. If the gradient is exactly zero, this will not work however. 
I'm not exactly sure what we should do in this case (maybe actually just reject that initial point?), but in this fix I just set those initial values to 1.