### PR TITLE
log_p output

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -194,6 +194,7 @@ where
             tuning: self.strategy.is_tuning(),
             step_size: self.hamiltonian.step_size(),
             num_steps: self.strategy.last_num_steps(),
+            log_p: state.log_p(),
         };
 
         self.strategy.adapt(

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -61,6 +61,7 @@ pub struct Progress {
     pub tuning: bool,
     pub step_size: f64,
     pub num_steps: u64,
+    pub log_p: f64
 }
 
 mod private {

--- a/src/state.rs
+++ b/src/state.rs
@@ -99,6 +99,10 @@ impl<M: Math, P: Point<M>> State<M, P> {
     pub fn energy(&self) -> f64 {
         self.point().energy()
     }
+
+    pub fn log_p(&self) -> f64 {
+        self.point().logp()
+    }
 }
 
 impl<M: Math, P: Point<M>> Drop for State<M, P> {


### PR DESCRIPTION
This would be a non breaking change to get `log_p` in the `draw` function of `Chain`

It feels a bit out of place in `Progress` but otherwise this would be a breaking change.

Potential fix for #37  